### PR TITLE
Check if the data is null when get platform arn

### DIFF
--- a/spec/SNSPushAdapter.spec.js
+++ b/spec/SNSPushAdapter.spec.js
@@ -158,6 +158,24 @@ describe('SNSPushAdapter', () => {
         });
     });
 
+    it('errors exchanging device tokens for an Amazon Resource Number (ARN) because data is null', (done) => {
+
+        // Mock out Amazon SNS token exchange
+        var snsSender = jasmine.createSpyObj('sns', ['createPlatformEndpoint']);
+        snsPushAdapter.sns = snsSender;
+
+        snsSender.createPlatformEndpoint.and.callFake(function(object, callback) {
+            callback("error", null);
+        });
+
+        var promise = snsPushAdapter.exchangeTokenPromise(makeDevice("androidToken"), "GCM_ID");
+
+        promise.catch(function() {
+            expect(snsSender.createPlatformEndpoint).toHaveBeenCalled();
+            done();
+        });
+    });
+
     it('errors exchanging device tokens for an Amazon Resource Number (ARN)', (done) => {
 
         // Mock out Amazon SNS token exchange

--- a/src/SNSPushAdapter.js
+++ b/src/SNSPushAdapter.js
@@ -173,7 +173,7 @@ SNSPushAdapter.prototype.exchangeTokenPromise = function (device, platformARN) {
     return new Parse.Promise((resolve, reject) => {
 
         this.getPlatformArn(device, platformARN, (err, data) => {
-            if (data.EndpointArn) {
+            if (data !== null && data.EndpointArn) {
                 resolve({device: device, arn: data.EndpointArn});
             }
             else


### PR DESCRIPTION
I sometimes get following error.

```
TypeError Cannot read property 'EndpointArn' of null 
    /usr/local/parse/node_modules/parse-server-sns-adapter/src/SNSPushAdapter.js:176:21 getPlatformArn
    /usr/local/parse/node_modules/parse-server-sns-adapter/node_modules/aws-sdk/lib/request.js:354:18 none
    /usr/local/parse/node_modules/parse-server-sns-adapter/node_modules/aws-sdk/lib/sequential_executor.js:105:20 callListeners
    /usr/local/parse/node_modules/parse-server-sns-adapter/node_modules/aws-sdk/lib/sequential_executor.js:77:10 emit
    /usr/local/parse/node_modules/parse-server-sns-adapter/node_modules/aws-sdk/lib/request.js:596:14 emit
    /usr/local/parse/node_modules/parse-server-sns-adapter/node_modules/aws-sdk/lib/request.js:21:10 transition
    /usr/local/parse/node_modules/parse-server-sns-adapter/node_modules/aws-sdk/lib/state_machine.js:14:12 runTo
```

to prevent this i fixed the code.
